### PR TITLE
Remove reload menu options.

### DIFF
--- a/lib/menu/index.js
+++ b/lib/menu/index.js
@@ -166,13 +166,10 @@ class ShellMenu {
                 label: app.getName(),
                 submenu: [
                     this.aboutItem,
-                    ShellMenu.createMenuItem('reload'),
                     { role: 'services', submenu: [] },
-                    ShellMenu.createMenuItem('reload'),
                     { role: 'hide' },
                     { role: 'hideothers' },
                     { role: 'unhide' },
-                    ShellMenu.createMenuItem('reload'),
                     { role: 'quit' },
                 ],
             };


### PR DESCRIPTION
Related to [this Trello ticket.](https://trello.com/c/K6nvj7My/253-macos-has-three-reload-menu-items).