### PR TITLE
fix: play large videos

### DIFF
--- a/lib/spa-stream-protocol-handler.js
+++ b/lib/spa-stream-protocol-handler.js
@@ -13,6 +13,26 @@ function getExtension(p) {
     return lastPart.slice(dotLocation + 1);
 }
 
+function getResponse(req, filePath) {
+    const fileStat = fs.statSync(filePath);
+    const headers = {};
+    // Handle video/audio streaming (or seeking)
+    if (req.headers.Range) {
+        const range = req.headers.Range;
+        const parts = range.replace(/bytes=/, '').split('-');
+        const start = parseInt(parts[0], 10);
+        const end = parts[1] ? parseInt(parts[1], 10) : fileStat.size - 1;
+        const chunkSize = (end - start) + 1;
+
+        headers['Content-Range'] = `bytes ${start}-${end}/${fileStat.size}`;
+        headers['Accept-Ranges'] = 'bytes';
+        headers['Content-Length'] = chunkSize;
+        return { status: 206, headers, stream: fs.createReadStream(filePath, { start, end }) };
+    }
+    headers['Content-Length'] = fileStat.size;
+    return { status: 200, headers, stream: fs.createReadStream(filePath) };
+}
+
 module.exports = function getHandler(root, opts = {}) {
     const fallback = opts.fallback || 'index.html';
     const postProcess = opts.postProcess || (s => s);
@@ -35,8 +55,11 @@ module.exports = function getHandler(root, opts = {}) {
         }
         const file = path.normalize(`${authorityRoot}/${filename}`);
         const mimeType = mime.lookup(extension);
-        const stream = fs.createReadStream(file);
+        const resData = getResponse(req, file);
+        const { stream, status, headers } = resData;
         const finalStream = postProcess(stream, mimeType, u);
-        callback({ statusCode: 200, headers: { 'content-type': mimeType, 'Access-Control-Allow-Origin': '*' }, data: finalStream });
+        headers['Content-Type'] = mimeType;
+        headers['Access-Control-Allow-Origin'] = '*';
+        callback({ statusCode: status, headers, data: finalStream });
     };
 };


### PR DESCRIPTION
 - Read the `Range` header and create the right stream from a file
 - Provide the content-length for all requests